### PR TITLE
Switch to GNOME runtime for WebKitGTK

### DIFF
--- a/com.netxms.NetXMSClient.yaml
+++ b/com.netxms.NetXMSClient.yaml
@@ -1,7 +1,7 @@
 app-id: com.netxms.NetXMSClient
-runtime: org.freedesktop.Sdk
-runtime-version: "25.08"
-sdk: org.freedesktop.Sdk
+runtime: org.gnome.Platform
+runtime-version: "50"
+sdk: org.gnome.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.openjdk17
 command: netxms-client.sh


### PR DESCRIPTION
The SWT Browser widget used for the welcome page requires WebKitGTK,
which org.freedesktop.Platform does not ship, causing 'Cannot create
browser widget' at startup. Switch to org.gnome.Platform//50, which
bundles WebKitGTK. The openjdk17 SDK extension resolves to the 25.08
freedesktop base via the runtime's extension point.
